### PR TITLE
Add stream status result

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -88,7 +88,6 @@ pub struct StreamResult {
     pub chan_mask: usize,
 }
 
-
 /// Transmit or Receive
 #[repr(u32)]
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
@@ -1147,9 +1146,7 @@ impl Device {
     // Master clock rate
     pub fn list_master_clock_rates(&self) -> Result<Vec<Range>, Error> {
         unsafe {
-            list_result(|len_ptr| {
-                SoapySDRDevice_getMasterClockRates(self.inner.ptr, len_ptr)
-            })
+            list_result(|len_ptr| SoapySDRDevice_getMasterClockRates(self.inner.ptr, len_ptr))
         }
     }
 
@@ -1217,6 +1214,46 @@ impl Device {
     pub fn read_setting<S: Into<Vec<u8>>>(&self, key: S) -> Result<String, Error> {
         let key = CString::new(key).expect("key must not contain null byte");
         unsafe { string_result(SoapySDRDevice_readSetting(self.inner.ptr, key.as_ptr())) }
+    }
+
+    /// Write a channel setting
+    pub fn write_channel_setting<S: Into<Vec<u8>>>(
+        &self,
+        direction: Direction,
+        channel: usize,
+        key: S,
+        value: S,
+    ) -> Result<(), Error> {
+        let key = CString::new(key).expect("key must not contain null byte");
+        let value = CString::new(value).expect("value must not contain null byte");
+        unsafe {
+            check_ret_error(SoapySDRDevice_writeChannelSetting(
+                self.inner.ptr,
+                direction.into(),
+                channel,
+                key.as_ptr(),
+                value.as_ptr(),
+            ))?;
+            Ok(())
+        }
+    }
+
+    /// Read a channel setting
+    pub fn read_channel_setting<S: Into<Vec<u8>>>(
+        &self,
+        direction: Direction,
+        channel: usize,
+        key: S,
+    ) -> Result<String, Error> {
+        let key = CString::new(key).expect("key must not contain null byte");
+        unsafe {
+            string_result(SoapySDRDevice_readChannelSetting(
+                self.inner.ptr,
+                direction.into(),
+                channel,
+                key.as_ptr(),
+            ))
+        }
     }
 
     // TODO: gpio
@@ -1348,7 +1385,11 @@ impl<E: StreamSample> RxStream<E> {
     ///
     /// # Panics
     ///  * If `buffers` is not the same length as the `channels` array passed to `Device::rx_stream`.
-    pub fn read(&mut self, buffers: &mut [&mut [E]], timeout_us: i64) -> Result<StreamResult, Error> {
+    pub fn read(
+        &mut self,
+        buffers: &mut [&mut [E]],
+        timeout_us: i64,
+    ) -> Result<StreamResult, Error> {
         unsafe {
             assert!(buffers.len() == self.nchannels);
 
@@ -1368,7 +1409,7 @@ impl<E: StreamSample> RxStream<E> {
                 timeout_us as _,
             ))?;
 
-            Ok(StreamResult{
+            Ok(StreamResult {
                 ret: len,
                 flags: self.flags,
                 time_ns: self.time_ns,
@@ -1592,8 +1633,7 @@ impl<E: StreamSample> TxStream<E> {
     //  * to report time errors, underflows, and burst completion.
     //  *
     //  */
-
-    pub fn read_status(&mut self, timeout_us: i64) -> Result<StreamResult, Error>{
+    pub fn read_status(&mut self, timeout_us: i64) -> Result<StreamResult, Error> {
         let mut sr = StreamResult {
             ret: 0,
             flags: 0,
@@ -1612,7 +1652,6 @@ impl<E: StreamSample> TxStream<E> {
         }
         Ok(sr)
     }
-
 
     // TODO: DMA
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -80,6 +80,15 @@ impl ::std::error::Error for Error {
     }
 }
 
+#[derive(Clone, Debug, Hash)]
+pub struct StreamResult {
+    pub ret: usize,
+    pub flags: i32,
+    pub time_ns: i64,
+    pub chan_mask: usize,
+}
+
+
 /// Transmit or Receive
 #[repr(u32)]
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
@@ -1317,7 +1326,7 @@ impl<E: StreamSample> RxStream<E> {
     ///
     /// # Panics
     ///  * If `buffers` is not the same length as the `channels` array passed to `Device::rx_stream`.
-    pub fn read(&mut self, buffers: &mut [&mut [E]], timeout_us: i64) -> Result<usize, Error> {
+    pub fn read(&mut self, buffers: &mut [&mut [E]], timeout_us: i64) -> Result<StreamResult, Error> {
         unsafe {
             assert!(buffers.len() == self.nchannels);
 
@@ -1336,8 +1345,13 @@ impl<E: StreamSample> RxStream<E> {
                 &mut self.time_ns as *mut _,
                 timeout_us as _,
             ))?;
-
-            Ok(len as usize)
+            // Is it better to return this StreamResult or just make the values public off of rx_stream
+            Ok(StreamResult{
+                ret: len as usize,
+                flags: self.flags,
+                time_ns: self.time_ns,
+                chan_mask: self.nchannels,
+            })
         }
     }
 }
@@ -1550,38 +1564,34 @@ impl<E: StreamSample> TxStream<E> {
         Ok(())
     }
 
-    /// Read the status of the stream.
-    /// 
-    /// This is required to detect underflows and such as they are not reported by 
-    /// [write](TxStream::write).
-    /// 
-    /// `chan_mask``, `flags``, and `time_ns`` are output parameters and _may_ be 
-    /// set depending on the type of status result.
-    /// 
-    /// Returns the status `Result`, usually this will be an [Error], as would be 
-    /// returned from a stream read/write.
-    /// 
-    /// [ErrorCode::Timeout] should generally be ignored.
-    /// 
-    /// Note that `timeout_us` is only `i32` on Windows and panics if the value is 
-    /// too large for `i32` on that platform.
-    pub fn read_status(&mut self, chan_mask: &mut usize, flags: &mut i32, time_ns: &mut i64, timeout_us: i64) -> Result<usize, Error> {
-        // Conversion needed for Windows, which takes an i32 here for some reason.
-        #[allow(clippy::useless_conversion)]
-        let timeout_us = timeout_us.try_into().unwrap();
+    // /*!
+    //  * Readback status information about a stream.
+    //  * This call is typically used on a transmit stream
+    //  * to report time errors, underflows, and burst completion.
+    //  *
+    //  */
+
+    pub fn read_status(&mut self, timeout_us: i64) -> Result<StreamResult, Error>{
+        let mut sr = StreamResult {
+            ret: 0,
+            flags: 0,
+            time_ns: 0,
+            chan_mask: 0,
+        };
         unsafe {
-            let status = len_result(SoapySDRDevice_readStreamStatus(
+            // or do i want check_result
+            sr.ret = len_result(SoapySDRDevice_readStreamStatus(
                 self.device.inner.ptr,
                 self.handle,
-                chan_mask,
-                flags,
-                time_ns,
-                timeout_us
-            ))?;
-
-            Ok(status as usize)
+                &mut sr.chan_mask as *mut _,
+                &mut sr.flags as *mut _,
+                &mut sr.time_ns as *mut _,
+                timeout_us as _,
+            ))? as usize;
         }
+        Ok(sr)
     }
+
 
     // TODO: DMA
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -82,7 +82,7 @@ impl ::std::error::Error for Error {
 
 #[derive(Clone, Debug, Hash)]
 pub struct StreamResult {
-    pub ret: usize,
+    pub ret: c_int,
     pub flags: i32,
     pub time_ns: i64,
     pub chan_mask: usize,
@@ -1345,9 +1345,9 @@ impl<E: StreamSample> RxStream<E> {
                 &mut self.time_ns as *mut _,
                 timeout_us as _,
             ))?;
-            // Is it better to return this StreamResult or just make the values public off of rx_stream
+
             Ok(StreamResult{
-                ret: len as usize,
+                ret: len,
                 flags: self.flags,
                 time_ns: self.time_ns,
                 chan_mask: self.nchannels,
@@ -1579,7 +1579,6 @@ impl<E: StreamSample> TxStream<E> {
             chan_mask: 0,
         };
         unsafe {
-            // or do i want check_result
             sr.ret = len_result(SoapySDRDevice_readStreamStatus(
                 self.device.inner.ptr,
                 self.handle,
@@ -1587,7 +1586,7 @@ impl<E: StreamSample> TxStream<E> {
                 &mut sr.flags as *mut _,
                 &mut sr.time_ns as *mut _,
                 timeout_us as _,
-            ))? as usize;
+            ))?;
         }
         Ok(sr)
     }

--- a/src/device.rs
+++ b/src/device.rs
@@ -1144,6 +1144,28 @@ impl Device {
         }
     }
 
+    // Master clock rate
+    pub fn list_master_clock_rates(&self) -> Result<Vec<Range>, Error> {
+        unsafe {
+            list_result(|len_ptr| {
+                SoapySDRDevice_getMasterClockRates(self.inner.ptr, len_ptr)
+            })
+        }
+    }
+
+    /// Get the current master clock rate
+    pub fn get_master_clock_rate(&self) -> Result<f64, Error> {
+        unsafe { check_error(SoapySDRDevice_getMasterClockRate(self.inner.ptr)) }
+    }
+
+    /// Set the current master_clock_rate
+    pub fn set_master_clock_rate(&self, clock_rate: f64) -> Result<(), Error> {
+        unsafe {
+            SoapySDRDevice_setMasterClockRate(self.inner.ptr, clock_rate);
+            check_error(())
+        }
+    }
+
     // TODO: sensors
 
     // Write a register

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ mod arginfo;
 pub use arginfo::ArgInfo;
 
 mod device;
-pub use device::{enumerate, Device, Direction, Error, ErrorCode, Range, RxStream, TxStream};
+pub use device::{enumerate, Device, Direction, Error, StreamResult, ErrorCode, Range, RxStream, TxStream};
 
 mod format;
 pub use format::{Format, StreamSample};


### PR DESCRIPTION
Update tx and rx streams to return the stream status including flags and time. This allows us to know if transit and read calls with time field were successfully completed.